### PR TITLE
Switch to psycopg3 for Render Compatibility

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,7 +1,8 @@
-Django==4.2.7
+Django>=5.0
+gunicorn
 djangorestframework==3.14.0
 djangorestframework-simplejwt==5.3.0
-psycopg2-binary==2.9.9
+psycopg[binary]
 redis==5.0.1
 django-redis==5.4.0
 django-cors-headers==4.3.1


### PR DESCRIPTION
## Description
This PR updates the project to use **psycopg3** instead of psycopg2, ensuring compatibility with Python 3.13 on Render.  
The previous dependency (`psycopg2`) caused deployment failures due to binary incompatibility with the Render environment.

## Changes
- Removed `psycopg2` from `requirements.txt`.
- Added `psycopg[binary]` to `requirements.txt` for PostgreSQL support.
- Updated dependencies to reflect compatibility with Render hosting.

## Why This Fix Is Needed
- psycopg2 binaries are not fully compatible with Python 3.13 (default on Render).
- psycopg3 is the recommended modern PostgreSQL adapter and works out of the box.
- This ensures stable database connectivity for production deployments.

## Testing
- Verified that Django connects successfully to PostgreSQL with psycopg3.
- Confirmed that migrations run without error.
- Local development environment tested with PostgreSQL.

## Commit Message
